### PR TITLE
- Downshifted to netstandard2.0 to support usage in net48

### DIFF
--- a/src/Pose/Helpers/StubHelper.cs
+++ b/src/Pose/Helpers/StubHelper.cs
@@ -80,7 +80,7 @@ namespace Pose.Helpers
                 if (genericArguments.Length > 0)
                 {
                     name += "[";
-                    name += string.Join(',', genericArguments.Select(g => g.Name));
+                    name += string.Join(",", genericArguments.Select(g => g.Name));
                     name += "]";
                 }
             }

--- a/src/Pose/IL/Stubs.cs
+++ b/src/Pose/IL/Stubs.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using Pose.Helpers;
 
 namespace Pose.IL
@@ -26,13 +27,19 @@ namespace Pose.IL
 
         static Stubs()
         {
-            s_getMethodFromHandleMethod = typeof(MethodBase).GetMethod("GetMethodFromHandle", new Type[] { typeof(RuntimeMethodHandle), typeof(RuntimeTypeHandle) });
-            s_createRewriterMethod = typeof(MethodRewriter).GetMethod("CreateRewriter", new Type[] { typeof(MethodBase), typeof(bool) });
-            s_rewriteMethod = typeof(MethodRewriter).GetMethod("Rewrite");
-            s_getMethodPointerMethod = typeof(StubHelper).GetMethod("GetMethodPointer");
-            s_devirtualizeMethodMethod = typeof(StubHelper).GetMethod("DevirtualizeMethod", new Type[] { typeof(object), typeof(MethodInfo) });
-            s_getTypeFromHandleMethod = typeof(Type).GetMethod("GetTypeFromHandle");
-            s_getUninitializedObjectMethod = typeof(RuntimeHelpers).GetMethod("GetUninitializedObject");
+            s_getMethodFromHandleMethod = typeof(MethodBase).GetMethod(nameof(MethodBase.GetMethodFromHandle), new Type[] { typeof(RuntimeMethodHandle), typeof(RuntimeTypeHandle) });
+            s_createRewriterMethod = typeof(MethodRewriter).GetMethod(nameof(MethodRewriter.CreateRewriter), new Type[] { typeof(MethodBase), typeof(bool) });
+            s_rewriteMethod = typeof(MethodRewriter).GetMethod(nameof(MethodRewriter.Rewrite));
+            s_getMethodPointerMethod = typeof(StubHelper).GetMethod(nameof(StubHelper.GetMethodPointer));
+            s_devirtualizeMethodMethod = typeof(StubHelper).GetMethod(nameof(StubHelper.DevirtualizeMethod), new Type[] { typeof(object), typeof(MethodInfo) });
+            s_getTypeFromHandleMethod = typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle));
+
+#if NETSTANDARD2_1
+            s_getUninitializedObjectMethod = typeof(RuntimeHelpers).GetMethod(nameof(RuntimeHelpers.GetUninitializedObject));
+#else
+            // see https://github.com/dotnet/runtime/blob/main/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultValueHolder.cs
+            s_getUninitializedObjectMethod = typeof(FormatterServices).GetMethod(nameof(FormatterServices.GetUninitializedObject));
+#endif
         }
 
         public static DynamicMethod GenerateStubForDirectCall(MethodBase method)

--- a/src/Pose/Pose.csproj
+++ b/src/Pose/Pose.csproj
@@ -3,7 +3,7 @@
     <Title>Pose</Title>
     <Description>Replace any .NET method (including static and non-virtual) with a delegate</Description>
     <PackageVersion>1.2.1</PackageVersion>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>Pose</AssemblyName>
     <PackageId>Pose</PackageId>

--- a/test/Pose.Tests/Pose.Tests.csproj
+++ b/test/Pose.Tests/Pose.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
As we are planning to use this as replacement for Microsoft Fakes, we need .net 4.8 support.
As .net 4.8 does not support netstandard2.1, downshift to 2.0 is required.